### PR TITLE
Sanitize `trim($year)` input to avoid poluting POST response

### DIFF
--- a/sources/libs/icalcreator/iCalcreator.class.php
+++ b/sources/libs/icalcreator/iCalcreator.class.php
@@ -8635,7 +8635,7 @@ class iCalUtilityFunctions {
       $parno           = iCalUtilityFunctions::_existRem( $input['params'], 'VALUE', 'DATE-TIME', $hitval, $parno );
       $input['value']  = iCalUtilityFunctions::_timestamp2date( $year, $parno );
     }
-    elseif( 8 <= strlen( trim( $year ))) { // ex. 2006-08-03 10:12:18
+    elseif( is_string( $year ) && ( 8 <= strlen( trim( $year )))) { // ex. 2006-08-03 10:12:18
       if( $localtime ) unset ( $month['VALUE'], $month['TZID'] );
       $input['params'] = iCalUtilityFunctions::_setParams( $month, array( 'VALUE' => 'DATE-TIME' ));
       if( isset( $input['params']['TZID'] )) {


### PR DESCRIPTION
To avoid php warning that may lead, depending on php configuration, to tainting of the served page/request output with a php warning.

With default agendav install from yunohost, that leads me to see a *parsingError* popup in the GUI each time I save an event to the calendar, then the event is added but I have to refresh the page if I want to see it appear on the calendar.

This PR fixes that bug.

For the record, ajax `POST /agendav/index.php/event/modify` request receive that :
```
<p>Severity: Warning</p>
<p>Message:  trim() expects parameter 1 to be string, array given</p>
<p>Filename: icalcreator/iCalcreator.class.php</p>
<p>Line Number: 8638</p>
{"result":"SUCCESS","message":["someone:default"]}
```
Which of course is not valid JSON.
Maybe a complementary edit would be to disable that warning logging to served responses.

Also reported upstream and up-upstream:
- https://github.com/adobo/agendav/pull/130
- https://github.com/iCalcreator/iCalcreator/pull/12/